### PR TITLE
doc: Add link to ccache docs for more description

### DIFF
--- a/doc/productivity.md
+++ b/doc/productivity.md
@@ -44,7 +44,7 @@ base_dir = /home/yourname  # or wherever you keep your source files
 
 Note: base_dir is required for ccache to share cached compiles of the same file across different repositories / paths; it will only do this for paths under base_dir. So this option is required for effective use of ccache with git worktrees (described below).
 
-You _must not_ set base_dir to "/", or anywhere that contains system headers (according to the ccache docs).
+You _must not_ set base_dir to "/", or anywhere that contains system headers (according to the [ccache docs](https://ccache.dev/manual/latest.html#_configuration_options)), since doing this will make ccache also rewrite paths to system header files, which typically is counterproductive.
 
 ### Disable features with `./configure`
 


### PR DESCRIPTION
Add description link to `base_dir` option in `ccache`.

Before
<img width="1063" alt="image" src="https://github.com/bitcoin/bitcoin/assets/73651621/00128a0f-2fb0-4cea-86c7-4e50ebdc6571">

After
<img width="1065" alt="image" src="https://github.com/bitcoin/bitcoin/assets/73651621/ca4dcedd-2c7e-41c8-90df-0c538a3e1c9d">
