### PR TITLE
[FreshEyes] Don't empty dbcache on prune flushes: >30% faster IBD

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -84,6 +84,7 @@ BITCOIN_TESTS =\
   test/bswap_tests.cpp \
   test/checkqueue_tests.cpp \
   test/coins_tests.cpp \
+  test/coinscachepair_tests.cpp \
   test/coinstatsindex_tests.cpp \
   test/common_url_tests.cpp \
   test/compilerbug_tests.cpp \

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -34,7 +34,9 @@ size_t CCoinsViewBacked::EstimateSize() const { return base->EstimateSize(); }
 CCoinsViewCache::CCoinsViewCache(CCoinsView* baseIn, bool deterministic) :
     CCoinsViewBacked(baseIn), m_deterministic(deterministic),
     cacheCoins(0, SaltedOutpointHasher(/*deterministic=*/deterministic), CCoinsMap::key_equal{}, &m_cache_coins_memory_resource)
-{}
+{
+    m_sentinel.second.SelfRef(m_sentinel);
+}
 
 size_t CCoinsViewCache::DynamicMemoryUsage() const {
     return memusage::DynamicUsage(cacheCoins) + cachedCoinsUsage;
@@ -51,7 +53,7 @@ CCoinsMap::iterator CCoinsViewCache::FetchCoin(const COutPoint &outpoint) const 
     if (ret->second.coin.IsSpent()) {
         // The parent only has an empty entry for this outpoint; we can consider our
         // version as fresh.
-        ret->second.AddFlags(CCoinsCacheEntry::FRESH);
+        ret->second.AddFlags(CCoinsCacheEntry::FRESH, *ret, m_sentinel);
     }
     cachedCoinsUsage += ret->second.coin.DynamicMemoryUsage();
     return ret;
@@ -96,7 +98,7 @@ void CCoinsViewCache::AddCoin(const COutPoint &outpoint, Coin&& coin, bool possi
         fresh = !it->second.IsDirty();
     }
     it->second.coin = std::move(coin);
-    it->second.AddFlags(CCoinsCacheEntry::DIRTY | (fresh ? CCoinsCacheEntry::FRESH : 0));
+    it->second.AddFlags(CCoinsCacheEntry::DIRTY | (fresh ? CCoinsCacheEntry::FRESH : 0), *it, m_sentinel);
     cachedCoinsUsage += it->second.coin.DynamicMemoryUsage();
     TRACE5(utxocache, add,
            outpoint.hash.data(),
@@ -113,7 +115,7 @@ void CCoinsViewCache::EmplaceCoinInternalDANGER(COutPoint&& outpoint, Coin&& coi
         std::forward_as_tuple(std::move(outpoint)),
         std::forward_as_tuple(std::move(coin)));
     if (inserted) {
-        it->second.AddFlags(CCoinsCacheEntry::DIRTY);
+        it->second.AddFlags(CCoinsCacheEntry::DIRTY, *it, m_sentinel);
     }
 }
 
@@ -144,7 +146,7 @@ bool CCoinsViewCache::SpendCoin(const COutPoint &outpoint, Coin* moveout) {
     if (it->second.IsFresh()) {
         cacheCoins.erase(it);
     } else {
-        it->second.AddFlags(CCoinsCacheEntry::DIRTY);
+        it->second.AddFlags(CCoinsCacheEntry::DIRTY, *it, m_sentinel);
         it->second.coin.Clear();
     }
     return true;
@@ -196,7 +198,8 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn
             if (!(it->second.IsFresh() && it->second.coin.IsSpent())) {
                 // Create the coin in the parent cache, move the data up
                 // and mark it as dirty.
-                CCoinsCacheEntry& entry = cacheCoins[it->first];
+                itUs = cacheCoins.try_emplace(it->first).first;
+                CCoinsCacheEntry& entry{itUs->second};
                 if (erase) {
                     // The `move` call here is purely an optimization; we rely on the
                     // `mapCoins.erase` call in the `for` expression to actually remove
@@ -206,12 +209,12 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn
                     entry.coin = it->second.coin;
                 }
                 cachedCoinsUsage += entry.coin.DynamicMemoryUsage();
-                entry.AddFlags(CCoinsCacheEntry::DIRTY);
+                entry.AddFlags(CCoinsCacheEntry::DIRTY, *itUs, m_sentinel);
                 // We can mark it FRESH in the parent if it was FRESH in the child
                 // Otherwise it might have just been flushed from the parent's cache
                 // and already exist in the grandparent
                 if (it->second.IsFresh()) {
-                    entry.AddFlags(CCoinsCacheEntry::FRESH);
+                    entry.AddFlags(CCoinsCacheEntry::FRESH, *itUs, m_sentinel);
                 }
             }
         } else {
@@ -241,7 +244,7 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn
                     itUs->second.coin = it->second.coin;
                 }
                 cachedCoinsUsage += itUs->second.coin.DynamicMemoryUsage();
-                itUs->second.AddFlags(CCoinsCacheEntry::DIRTY);
+                itUs->second.AddFlags(CCoinsCacheEntry::DIRTY, *itUs, m_sentinel);
                 // NOTE: It isn't safe to mark the coin as FRESH in the parent
                 // cache. If it already existed and was spent in the parent
                 // cache then marking it FRESH would prevent that spentness

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -108,10 +108,13 @@ void CCoinsViewCache::AddCoin(const COutPoint &outpoint, Coin&& coin, bool possi
 
 void CCoinsViewCache::EmplaceCoinInternalDANGER(COutPoint&& outpoint, Coin&& coin) {
     cachedCoinsUsage += coin.DynamicMemoryUsage();
-    cacheCoins.emplace(
+    auto [it, inserted] = cacheCoins.emplace(
         std::piecewise_construct,
         std::forward_as_tuple(std::move(outpoint)),
-        std::forward_as_tuple(std::move(coin), CCoinsCacheEntry::DIRTY));
+        std::forward_as_tuple(std::move(coin)));
+    if (inserted) {
+        it->second.AddFlags(CCoinsCacheEntry::DIRTY);
+    }
 }
 
 void AddCoins(CCoinsViewCache& cache, const CTransaction &tx, int nHeight, bool check_for_overwrite) {

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -38,6 +38,12 @@ CCoinsViewCache::CCoinsViewCache(CCoinsView* baseIn, bool deterministic) :
     m_sentinel.second.SelfRef(m_sentinel);
 }
 
+CCoinsViewCache::~CCoinsViewCache()
+{
+    cacheCoins.clear();
+    Assume(m_sentinel.second.Next() == &m_sentinel);
+}
+
 size_t CCoinsViewCache::DynamicMemoryUsage() const {
     return memusage::DynamicUsage(cacheCoins) + cachedCoinsUsage;
 }

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -326,6 +326,7 @@ void CCoinsViewCache::ReallocateCache()
 void CCoinsViewCache::SanityCheck() const
 {
     size_t recomputed_usage = 0;
+    size_t count_flagged = 0;
     for (const auto& [_, entry] : cacheCoins) {
         unsigned attr = 0;
         if (entry.IsDirty()) attr |= 1;
@@ -336,7 +337,22 @@ void CCoinsViewCache::SanityCheck() const
 
         // Recompute cachedCoinsUsage.
         recomputed_usage += entry.coin.DynamicMemoryUsage();
+
+        // Count the number of entries we expect in the linked list.
+        if (entry.IsDirty() || entry.IsFresh()) ++count_flagged;
     }
+    // Iterate over the linked list of flagged entries.
+    size_t count_linked = 0;
+    for (auto it = m_sentinel.second.Next(); it != &m_sentinel; it = it->second.Next()) {
+        // Verify linked list integrity.
+        assert(it->second.Next()->second.Prev() == it);
+        assert(it->second.Prev()->second.Next() == it);
+        // Verify they are actually flagged.
+        assert(it->second.IsDirty() || it->second.IsFresh());
+        // Count the number of entries actually in the list.
+        ++count_linked;
+    }
+    assert(count_linked == count_flagged);
     assert(recomputed_usage == cachedCoinsUsage);
 }
 

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -12,7 +12,7 @@
 bool CCoinsView::GetCoin(const COutPoint &outpoint, Coin &coin) const { return false; }
 uint256 CCoinsView::GetBestBlock() const { return uint256(); }
 std::vector<uint256> CCoinsView::GetHeadBlocks() const { return std::vector<uint256>(); }
-bool CCoinsView::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, bool erase) { return false; }
+bool CCoinsView::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashBlock) { return false; }
 std::unique_ptr<CCoinsViewCursor> CCoinsView::Cursor() const { return nullptr; }
 
 bool CCoinsView::HaveCoin(const COutPoint &outpoint) const
@@ -27,7 +27,7 @@ bool CCoinsViewBacked::HaveCoin(const COutPoint &outpoint) const { return base->
 uint256 CCoinsViewBacked::GetBestBlock() const { return base->GetBestBlock(); }
 std::vector<uint256> CCoinsViewBacked::GetHeadBlocks() const { return base->GetHeadBlocks(); }
 void CCoinsViewBacked::SetBackend(CCoinsView &viewIn) { base = &viewIn; }
-bool CCoinsViewBacked::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, bool erase) { return base->BatchWrite(mapCoins, hashBlock, erase); }
+bool CCoinsViewBacked::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashBlock) { return base->BatchWrite(cursor, hashBlock); }
 std::unique_ptr<CCoinsViewCursor> CCoinsViewBacked::Cursor() const { return base->Cursor(); }
 size_t CCoinsViewBacked::EstimateSize() const { return base->EstimateSize(); }
 
@@ -189,10 +189,8 @@ void CCoinsViewCache::SetBestBlock(const uint256 &hashBlockIn) {
     hashBlock = hashBlockIn;
 }
 
-bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn, bool erase) {
-    for (CCoinsMap::iterator it = mapCoins.begin();
-            it != mapCoins.end();
-            it = erase ? mapCoins.erase(it) : std::next(it)) {
+bool CCoinsViewCache::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashBlockIn) {
+    for (auto it{cursor.Begin()}; it != cursor.End(); it = cursor.Next(*it)) {
         // Ignore non-dirty entries (optimization).
         if (!it->second.IsDirty()) {
             continue;
@@ -206,10 +204,9 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn
                 // and mark it as dirty.
                 itUs = cacheCoins.try_emplace(it->first).first;
                 CCoinsCacheEntry& entry{itUs->second};
-                if (erase) {
-                    // The `move` call here is purely an optimization; we rely on the
-                    // `mapCoins.erase` call in the `for` expression to actually remove
-                    // the entry from the child map.
+                if (cursor.WillErase(*it)) {
+                    // Since this entry will be erased,
+                    // we can move the coin into us instead of copying it
                     entry.coin = std::move(it->second.coin);
                 } else {
                     entry.coin = it->second.coin;
@@ -241,10 +238,9 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn
             } else {
                 // A normal modification.
                 cachedCoinsUsage -= itUs->second.coin.DynamicMemoryUsage();
-                if (erase) {
-                    // The `move` call here is purely an optimization; we rely on the
-                    // `mapCoins.erase` call in the `for` expression to actually remove
-                    // the entry from the child map.
+                if (cursor.WillErase(*it)) {
+                    // Since this entry will be erased,
+                    // we can move the coin into us instead of copying it
                     itUs->second.coin = std::move(it->second.coin);
                 } else {
                     itUs->second.coin = it->second.coin;
@@ -263,12 +259,10 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn
 }
 
 bool CCoinsViewCache::Flush() {
-    bool fOk = base->BatchWrite(cacheCoins, hashBlock, /*erase=*/true);
+    auto cursor{CoinsViewCacheCursor(cachedCoinsUsage, m_sentinel, cacheCoins, /*will_erase=*/true)};
+    bool fOk = base->BatchWrite(cursor, hashBlock);
     if (fOk) {
-        if (!cacheCoins.empty()) {
-            /* BatchWrite must erase all cacheCoins elements when erase=true. */
-            throw std::logic_error("Not all cached coins were erased");
-        }
+        cacheCoins.clear();
         ReallocateCache();
     }
     cachedCoinsUsage = 0;
@@ -277,7 +271,8 @@ bool CCoinsViewCache::Flush() {
 
 bool CCoinsViewCache::Sync()
 {
-    bool fOk = base->BatchWrite(cacheCoins, hashBlock, /*erase=*/false);
+    auto cursor{CoinsViewCacheCursor(cachedCoinsUsage, m_sentinel, cacheCoins, /*will_erase=*/false)};
+    bool fOk = base->BatchWrite(cursor, hashBlock);
     // Instead of clearing `cacheCoins` as we would in Flush(), just clear the
     // FRESH/DIRTY flags of any coin that isn't spent.
     for (auto it = cacheCoins.begin(); it != cacheCoins.end(); ) {

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -273,15 +273,10 @@ bool CCoinsViewCache::Sync()
 {
     auto cursor{CoinsViewCacheCursor(cachedCoinsUsage, m_sentinel, cacheCoins, /*will_erase=*/false)};
     bool fOk = base->BatchWrite(cursor, hashBlock);
-    // Instead of clearing `cacheCoins` as we would in Flush(), just clear the
-    // FRESH/DIRTY flags of any coin that isn't spent.
-    for (auto it = cacheCoins.begin(); it != cacheCoins.end(); ) {
-        if (it->second.coin.IsSpent()) {
-            cachedCoinsUsage -= it->second.coin.DynamicMemoryUsage();
-            it = cacheCoins.erase(it);
-        } else {
-            it->second.ClearFlags();
-            ++it;
+    if (fOk) {
+        if (m_sentinel.second.Next() != &m_sentinel) {
+            /* BatchWrite must clear flags of all entries */
+            throw std::logic_error("Not all unspent flagged entries were cleared");
         }
     }
     return fOk;

--- a/src/coins.h
+++ b/src/coins.h
@@ -136,6 +136,10 @@ public:
 
     CCoinsCacheEntry() noexcept = default;
     explicit CCoinsCacheEntry(Coin&& coin_) noexcept : coin(std::move(coin_)) {}
+    ~CCoinsCacheEntry()
+    {
+        ClearFlags();
+    }
 
     //! Adding a flag also requires a self reference to the pair that contains
     //! this entry in the CCoinsCache map and a reference to the sentinel of the

--- a/src/coins.h
+++ b/src/coins.h
@@ -131,6 +131,11 @@ struct CCoinsCacheEntry
     explicit CCoinsCacheEntry(Coin&& coin_) : coin(std::move(coin_)), flags(0) {}
     CCoinsCacheEntry(Coin&& coin_, unsigned char flag) : coin(std::move(coin_)), flags(flag) {}
 
+    inline void AddFlags(unsigned char flags) noexcept { this->flags |= flags; }
+    inline void ClearFlags() noexcept
+    {
+        flags = 0;
+    }
     inline unsigned char GetFlags() const noexcept { return flags; }
     inline bool IsDirty() const noexcept { return flags & DIRTY; }
     inline bool IsFresh() const noexcept { return flags & FRESH; }

--- a/src/coins.h
+++ b/src/coins.h
@@ -130,6 +130,9 @@ struct CCoinsCacheEntry
     CCoinsCacheEntry() : flags(0) {}
     explicit CCoinsCacheEntry(Coin&& coin_) : coin(std::move(coin_)), flags(0) {}
     CCoinsCacheEntry(Coin&& coin_, unsigned char flag) : coin(std::move(coin_)), flags(flag) {}
+
+    inline bool IsDirty() const noexcept { return flags & DIRTY; }
+    inline bool IsFresh() const noexcept { return flags & FRESH; }
 };
 
 /**

--- a/src/coins.h
+++ b/src/coins.h
@@ -103,8 +103,11 @@ public:
  */
 struct CCoinsCacheEntry
 {
+private:
+    uint8_t m_flags{0};
+
+public:
     Coin coin; // The actual cached data.
-    unsigned char flags{0};
 
     enum Flags {
         /**
@@ -130,14 +133,14 @@ struct CCoinsCacheEntry
     CCoinsCacheEntry() noexcept = default;
     explicit CCoinsCacheEntry(Coin&& coin_) noexcept : coin(std::move(coin_)) {}
 
-    inline void AddFlags(unsigned char flags) noexcept { this->flags |= flags; }
+    inline void AddFlags(uint8_t flags) noexcept { m_flags |= flags; }
     inline void ClearFlags() noexcept
     {
-        flags = 0;
+        m_flags = 0;
     }
-    inline unsigned char GetFlags() const noexcept { return flags; }
-    inline bool IsDirty() const noexcept { return flags & DIRTY; }
-    inline bool IsFresh() const noexcept { return flags & FRESH; }
+    inline uint8_t GetFlags() const noexcept { return m_flags; }
+    inline bool IsDirty() const noexcept { return m_flags & DIRTY; }
+    inline bool IsFresh() const noexcept { return m_flags & FRESH; }
 };
 
 /**

--- a/src/coins.h
+++ b/src/coins.h
@@ -86,6 +86,9 @@ public:
     }
 };
 
+struct CCoinsCacheEntry;
+using CoinsCachePair = std::pair<const COutPoint, CCoinsCacheEntry>;
+
 /**
  * A Coin in one level of the coins database caching hierarchy.
  *
@@ -155,8 +158,8 @@ using CCoinsMap = std::unordered_map<COutPoint,
                                      CCoinsCacheEntry,
                                      SaltedOutpointHasher,
                                      std::equal_to<COutPoint>,
-                                     PoolAllocator<std::pair<const COutPoint, CCoinsCacheEntry>,
-                                                   sizeof(std::pair<const COutPoint, CCoinsCacheEntry>) + sizeof(void*) * 4>>;
+                                     PoolAllocator<CoinsCachePair,
+                                                   sizeof(CoinsCachePair) + sizeof(void*) * 4>>;
 
 using CCoinsMapMemoryResource = CCoinsMap::allocator_type::ResourceType;
 

--- a/src/coins.h
+++ b/src/coins.h
@@ -104,7 +104,7 @@ public:
 struct CCoinsCacheEntry
 {
     Coin coin; // The actual cached data.
-    unsigned char flags;
+    unsigned char flags{0};
 
     enum Flags {
         /**
@@ -127,9 +127,8 @@ struct CCoinsCacheEntry
         FRESH = (1 << 1),
     };
 
-    CCoinsCacheEntry() : flags(0) {}
-    explicit CCoinsCacheEntry(Coin&& coin_) : coin(std::move(coin_)), flags(0) {}
-    CCoinsCacheEntry(Coin&& coin_, unsigned char flag) : coin(std::move(coin_)), flags(flag) {}
+    CCoinsCacheEntry() noexcept = default;
+    explicit CCoinsCacheEntry(Coin&& coin_) noexcept : coin(std::move(coin_)) {}
 
     inline void AddFlags(unsigned char flags) noexcept { this->flags |= flags; }
     inline void ClearFlags() noexcept

--- a/src/coins.h
+++ b/src/coins.h
@@ -131,6 +131,7 @@ struct CCoinsCacheEntry
     explicit CCoinsCacheEntry(Coin&& coin_) : coin(std::move(coin_)), flags(0) {}
     CCoinsCacheEntry(Coin&& coin_, unsigned char flag) : coin(std::move(coin_)), flags(flag) {}
 
+    inline unsigned char GetFlags() const noexcept { return flags; }
     inline bool IsDirty() const noexcept { return flags & DIRTY; }
     inline bool IsFresh() const noexcept { return flags & FRESH; }
 };

--- a/src/coins.h
+++ b/src/coins.h
@@ -108,6 +108,24 @@ using CoinsCachePair = std::pair<const COutPoint, CCoinsCacheEntry>;
 struct CCoinsCacheEntry
 {
 private:
+    /**
+     * These are used to create a doubly linked list of flagged entries.
+     * They are set in AddFlags and unset in ClearFlags.
+     * A flagged entry is any entry that is either DIRTY, FRESH, or both.
+     *
+     * DIRTY entries are tracked so that only modified entries can be passed to
+     * the parent cache for batch writing. This is a performance optimization
+     * compared to giving all entries in the cache to the parent and having the
+     * parent scan for only modified entries.
+     *
+     * FRESH-but-not-DIRTY coins can not occur in practice, since that would
+     * mean a spent coin exists in the parent CCoinsView and not in the child
+     * CCoinsViewCache. Nevertheless, if a spent coin is retrieved from the
+     * parent cache, the FRESH-but-not-DIRTY coin will be tracked by the linked
+     * list and deleted when Sync or Flush is called on the CCoinsViewCache.
+     */
+    CoinsCachePair* m_prev{nullptr};
+    CoinsCachePair* m_next{nullptr};
     uint8_t m_flags{0};
 
 public:
@@ -147,20 +165,32 @@ public:
     inline void AddFlags(uint8_t flags, CoinsCachePair& self, CoinsCachePair& sentinel) noexcept
     {
         Assume(&self.second == this);
+        if (!m_flags && flags) {
+            m_prev = sentinel.second.m_prev;
+            m_next = &sentinel;
+            sentinel.second.m_prev = &self;
+            m_prev->second.m_next = &self;
+        }
         m_flags |= flags;
     }
     inline void ClearFlags() noexcept
     {
+        if (!m_flags) return;
+        m_next->second.m_prev = m_prev;
+        m_prev->second.m_next = m_next;
         m_flags = 0;
     }
     inline uint8_t GetFlags() const noexcept { return m_flags; }
     inline bool IsDirty() const noexcept { return m_flags & DIRTY; }
     inline bool IsFresh() const noexcept { return m_flags & FRESH; }
+    inline CoinsCachePair* Next() const noexcept { return m_next; }
 
     //! Only use this for initializing the linked list sentinel
     inline void SelfRef(CoinsCachePair& self) noexcept
     {
         Assume(&self.second == this);
+        m_prev = &self;
+        m_next = &self;
     }
 };
 
@@ -278,6 +308,7 @@ protected:
 
 public:
     CCoinsViewCache(CCoinsView *baseIn, bool deterministic = false);
+    ~CCoinsViewCache();
 
     /**
      * By deleting the copy constructor, we prevent accidentally using it when one intends to create a cache on top of a base cache.

--- a/src/coins.h
+++ b/src/coins.h
@@ -184,6 +184,7 @@ public:
     inline bool IsDirty() const noexcept { return m_flags & DIRTY; }
     inline bool IsFresh() const noexcept { return m_flags & FRESH; }
     inline CoinsCachePair* Next() const noexcept { return m_next; }
+    inline CoinsCachePair* Prev() const noexcept { return m_prev; }
 
     //! Only use this for initializing the linked list sentinel
     inline void SelfRef(CoinsCachePair& self) noexcept

--- a/src/coins.h
+++ b/src/coins.h
@@ -230,6 +230,27 @@ private:
     uint256 hashBlock;
 };
 
+/**
+ * Cursor for iterating over the linked list of flagged entries in CCoinsViewCache.
+ */
+struct CoinsViewCacheCursor
+{
+    CoinsViewCacheCursor(size_t& usage LIFETIMEBOUND, CoinsCachePair& sentinel LIFETIMEBOUND, CCoinsMap& map LIFETIMEBOUND, bool will_erase) noexcept
+        : m_usage(usage), m_sentinel(sentinel), m_map(map), m_will_erase(will_erase) {}
+
+    inline CoinsCachePair* Begin() const noexcept { return m_sentinel.second.Next(); }
+    inline CoinsCachePair* End() const noexcept { return &m_sentinel; }
+
+    inline CoinsCachePair* Next(CoinsCachePair& current) noexcept { return current.second.Next(); }
+
+    inline bool WillErase(CoinsCachePair& current) const noexcept { return m_will_erase; }
+private:
+    size_t& m_usage;
+    CoinsCachePair& m_sentinel;
+    CCoinsMap& m_map;
+    bool m_will_erase;
+};
+
 /** Abstract view on the open txout dataset. */
 class CCoinsView
 {
@@ -253,8 +274,8 @@ public:
     virtual std::vector<uint256> GetHeadBlocks() const;
 
     //! Do a bulk modification (multiple Coin changes + BestBlock change).
-    //! The passed mapCoins can be modified.
-    virtual bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, bool erase = true);
+    //! The passed cursor is used to iterate through the coins.
+    virtual bool BatchWrite(CoinsViewCacheCursor& cursor, const uint256& hashBlock);
 
     //! Get a cursor to iterate over the whole state
     virtual std::unique_ptr<CCoinsViewCursor> Cursor() const;
@@ -280,7 +301,7 @@ public:
     uint256 GetBestBlock() const override;
     std::vector<uint256> GetHeadBlocks() const override;
     void SetBackend(CCoinsView &viewIn);
-    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, bool erase = true) override;
+    bool BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashBlock) override;
     std::unique_ptr<CCoinsViewCursor> Cursor() const override;
     size_t EstimateSize() const override;
 };
@@ -320,7 +341,7 @@ public:
     bool HaveCoin(const COutPoint &outpoint) const override;
     uint256 GetBestBlock() const override;
     void SetBestBlock(const uint256 &hashBlock);
-    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, bool erase = true) override;
+    bool BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashBlock) override;
     std::unique_ptr<CCoinsViewCursor> Cursor() const override {
         throw std::logic_error("CCoinsViewCache cursor iteration not supported.");
     }

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -58,7 +58,7 @@ public:
     bool BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlock, bool erase = true) override
     {
         for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end(); it = erase ? mapCoins.erase(it) : std::next(it)) {
-            if (it->second.flags & CCoinsCacheEntry::DIRTY) {
+            if (it->second.IsDirty()) {
                 // Same optimization used in CCoinsViewDB is to only write dirty entries.
                 map_[it->first] = it->second.coin;
                 if (it->second.coin.IsSpent() && InsecureRandRange(3) == 0) {

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -584,7 +584,7 @@ static size_t InsertCoinsMapEntry(CCoinsMap& map, CAmount value, char flags)
     }
     assert(flags != NO_ENTRY);
     CCoinsCacheEntry entry;
-    entry.flags = flags;
+    entry.AddFlags(flags);
     SetCoinsValue(value, entry.coin);
     auto inserted = map.emplace(OUTPOINT, std::move(entry));
     assert(inserted.second);

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -603,7 +603,7 @@ void GetCoinsMapEntry(const CCoinsMap& map, CAmount& value, char& flags, const C
         } else {
             value = it->second.coin.out.nValue;
         }
-        flags = it->second.flags;
+        flags = it->second.GetFlags();
         assert(flags != NO_ENTRY);
     }
 }

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -55,9 +55,9 @@ public:
 
     uint256 GetBestBlock() const override { return hashBestBlock_; }
 
-    bool BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlock, bool erase = true) override
+    bool BatchWrite(CoinsViewCacheCursor& cursor, const uint256& hashBlock) override
     {
-        for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end(); it = erase ? mapCoins.erase(it) : std::next(it)) {
+        for (auto it{cursor.Begin()}; it != cursor.End(); it = cursor.Next(*it)){
             if (it->second.IsDirty()) {
                 // Same optimization used in CCoinsViewDB is to only write dirty entries.
                 map_[it->first] = it->second.coin;
@@ -618,8 +618,9 @@ void WriteCoinsViewEntry(CCoinsView& view, CAmount value, char flags)
     sentinel.second.SelfRef(sentinel);
     CCoinsMapMemoryResource resource;
     CCoinsMap map{0, CCoinsMap::hasher{}, CCoinsMap::key_equal{}, &resource};
-    InsertCoinsMapEntry(map, sentinel, value, flags);
-    BOOST_CHECK(view.BatchWrite(map, {}));
+    auto usage{InsertCoinsMapEntry(map, sentinel, value, flags)};
+    auto cursor{CoinsViewCacheCursor(usage, sentinel, map, /*will_erase=*/true)};
+    BOOST_CHECK(view.BatchWrite(cursor, {}));
 }
 
 class SingleEntryCacheTest

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -92,6 +92,7 @@ public:
     }
 
     CCoinsMap& map() const { return cacheCoins; }
+    CoinsCachePair& sentinel() const { return m_sentinel; }
     size_t& usage() const { return cachedCoinsUsage; }
 };
 
@@ -576,7 +577,7 @@ static void SetCoinsValue(CAmount value, Coin& coin)
     }
 }
 
-static size_t InsertCoinsMapEntry(CCoinsMap& map, CAmount value, char flags)
+static size_t InsertCoinsMapEntry(CCoinsMap& map, CoinsCachePair& sentinel, CAmount value, char flags)
 {
     if (value == ABSENT) {
         assert(flags == NO_ENTRY);
@@ -584,10 +585,10 @@ static size_t InsertCoinsMapEntry(CCoinsMap& map, CAmount value, char flags)
     }
     assert(flags != NO_ENTRY);
     CCoinsCacheEntry entry;
-    entry.AddFlags(flags);
     SetCoinsValue(value, entry.coin);
     auto inserted = map.emplace(OUTPOINT, std::move(entry));
     assert(inserted.second);
+    inserted.first->second.AddFlags(flags, *inserted.first, sentinel);
     return inserted.first->second.coin.DynamicMemoryUsage();
 }
 
@@ -610,9 +611,14 @@ void GetCoinsMapEntry(const CCoinsMap& map, CAmount& value, char& flags, const C
 
 void WriteCoinsViewEntry(CCoinsView& view, CAmount value, char flags)
 {
+    // sentinel must go out of scope and be destroyed after map.
+    // Any remaining flagged entries in map need to reference the sentinel
+    // when they are destroyed.
+    CoinsCachePair sentinel{};
+    sentinel.second.SelfRef(sentinel);
     CCoinsMapMemoryResource resource;
     CCoinsMap map{0, CCoinsMap::hasher{}, CCoinsMap::key_equal{}, &resource};
-    InsertCoinsMapEntry(map, value, flags);
+    InsertCoinsMapEntry(map, sentinel, value, flags);
     BOOST_CHECK(view.BatchWrite(map, {}));
 }
 
@@ -622,7 +628,7 @@ public:
     SingleEntryCacheTest(CAmount base_value, CAmount cache_value, char cache_flags)
     {
         WriteCoinsViewEntry(base, base_value, base_value == ABSENT ? NO_ENTRY : DIRTY);
-        cache.usage() += InsertCoinsMapEntry(cache.map(), cache_value, cache_flags);
+        cache.usage() += InsertCoinsMapEntry(cache.map(), cache.sentinel(), cache_value, cache_flags);
     }
 
     CCoinsView root;

--- a/src/test/coinscachepair_tests.cpp
+++ b/src/test/coinscachepair_tests.cpp
@@ -1,0 +1,194 @@
+// Copyright (c) 2024-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <coins.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <list>
+
+BOOST_AUTO_TEST_SUITE(coinscachepair_tests)
+
+static constexpr auto NUM_NODES{4};
+
+std::list<CoinsCachePair> CreatePairs(CoinsCachePair& sentinel)
+{
+    std::list<CoinsCachePair> nodes;
+    for (auto i{0}; i < NUM_NODES; ++i) {
+        nodes.emplace_back();
+
+        auto node{std::prev(nodes.end())};
+        node->second.AddFlags(CCoinsCacheEntry::DIRTY, *node, sentinel);
+
+        BOOST_CHECK_EQUAL(node->second.GetFlags(), CCoinsCacheEntry::DIRTY);
+        BOOST_CHECK_EQUAL(node->second.Next(), &sentinel);
+
+        if (i > 0) {
+            BOOST_CHECK_EQUAL(std::prev(node)->second.Next(), &(*node));
+        }
+    }
+    return nodes;
+}
+
+BOOST_AUTO_TEST_CASE(linked_list_iteration)
+{
+    CoinsCachePair sentinel;
+    sentinel.second.SelfRef(sentinel);
+    auto nodes{CreatePairs(sentinel)};
+
+    // Check iterating through pairs is identical to iterating through a list
+    auto node{sentinel.second.Next()};
+    for (const auto& expected : nodes) {
+        BOOST_CHECK_EQUAL(&expected, node);
+        node = node->second.Next();
+    }
+    BOOST_CHECK_EQUAL(node, &sentinel);
+
+    // Check iterating through pairs is identical to iterating through a list
+    // Clear the flags during iteration
+    node = sentinel.second.Next();
+    for (const auto& expected : nodes) {
+        BOOST_CHECK_EQUAL(&expected, node);
+        node->second.ClearFlags();
+        node = node->second.Next();
+    }
+    BOOST_CHECK_EQUAL(node, &sentinel);
+    // Check that sentinel's next is itself
+    BOOST_CHECK_EQUAL(sentinel.second.Next(), &sentinel);
+
+    // Delete the nodes from the list to make sure there are no dangling pointers
+    for (auto it{nodes.begin()}; it != nodes.end(); it = nodes.erase(it)) {
+        BOOST_CHECK_EQUAL(it->second.GetFlags(), 0);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(linked_list_iterate_erase)
+{
+    CoinsCachePair sentinel;
+    sentinel.second.SelfRef(sentinel);
+    auto nodes{CreatePairs(sentinel)};
+
+    // Check iterating through pairs is identical to iterating through a list
+    // Erase the nodes as we iterate through, but don't clear flags
+    // The flags will be cleared by the CCoinsCacheEntry's destructor
+    auto node{sentinel.second.Next()};
+    for (auto expected{nodes.begin()}; expected != nodes.end(); expected = nodes.erase(expected)) {
+        BOOST_CHECK_EQUAL(&(*expected), node);
+        node = node->second.Next();
+    }
+    BOOST_CHECK_EQUAL(node, &sentinel);
+
+    // Check that sentinel's next is itself
+    BOOST_CHECK_EQUAL(sentinel.second.Next(), &sentinel);
+}
+
+BOOST_AUTO_TEST_CASE(linked_list_random_deletion)
+{
+    CoinsCachePair sentinel;
+    sentinel.second.SelfRef(sentinel);
+    auto nodes{CreatePairs(sentinel)};
+
+    // Create linked list sentinel->n1->n2->n3->n4->sentinel
+    auto n1{nodes.begin()};
+    auto n2{std::next(n1)};
+    auto n3{std::next(n2)};
+    auto n4{std::next(n3)};
+
+    // Delete n2
+    // sentinel->n1->n3->n4->sentinel
+    nodes.erase(n2);
+    // Check that n1 now points to n3, and n3 still points to n4
+    // Also check that flags were not altered
+    BOOST_CHECK_EQUAL(n1->second.GetFlags(), CCoinsCacheEntry::DIRTY);
+    BOOST_CHECK_EQUAL(n1->second.Next(), &(*n3));
+    BOOST_CHECK_EQUAL(n3->second.GetFlags(), CCoinsCacheEntry::DIRTY);
+    BOOST_CHECK_EQUAL(n3->second.Next(), &(*n4));
+
+    // Delete n1
+    // sentinel->n3->n4->sentinel
+    nodes.erase(n1);
+    // Check that sentinel now points to n3, and n3 still points to n4
+    // Also check that flags were not altered
+    BOOST_CHECK_EQUAL(n3->second.GetFlags(), CCoinsCacheEntry::DIRTY);
+    BOOST_CHECK_EQUAL(sentinel.second.Next(), &(*n3));
+    BOOST_CHECK_EQUAL(n3->second.Next(), &(*n4));
+
+    // Delete n4
+    // sentinel->n3->sentinel
+    nodes.erase(n4);
+    // Check that sentinel still points to n3, and n3 points to sentinel
+    // Also check that flags were not altered
+    BOOST_CHECK_EQUAL(n3->second.GetFlags(), CCoinsCacheEntry::DIRTY);
+    BOOST_CHECK_EQUAL(sentinel.second.Next(), &(*n3));
+    BOOST_CHECK_EQUAL(n3->second.Next(), &sentinel);
+
+    // Delete n3
+    // sentinel->sentinel
+    nodes.erase(n3);
+    // Check that sentinel's next now points to itself
+    BOOST_CHECK_EQUAL(sentinel.second.Next(), &sentinel);
+}
+
+BOOST_AUTO_TEST_CASE(linked_list_add_flags)
+{
+    CoinsCachePair sentinel;
+    sentinel.second.SelfRef(sentinel);
+    CoinsCachePair n1;
+    CoinsCachePair n2;
+
+    // Check that adding 0 flag has no effect
+    n1.second.AddFlags(0, n1, sentinel);
+    BOOST_CHECK_EQUAL(n1.second.GetFlags(), 0);
+    BOOST_CHECK_EQUAL(n1.second.Next(), nullptr);
+    BOOST_CHECK_EQUAL(sentinel.second.Next(), &sentinel);
+
+    // Check that adding DIRTY flag inserts it into linked list and sets flags
+    n1.second.AddFlags(CCoinsCacheEntry::DIRTY, n1, sentinel);
+    BOOST_CHECK_EQUAL(n1.second.GetFlags(), CCoinsCacheEntry::DIRTY);
+    BOOST_CHECK_EQUAL(n1.second.Next(), &sentinel);
+    BOOST_CHECK_EQUAL(sentinel.second.Next(), &n1);
+
+    // Check that adding FRESH flag on new node inserts it after n1
+    n2.second.AddFlags(CCoinsCacheEntry::FRESH, n2, sentinel);
+    BOOST_CHECK_EQUAL(n2.second.GetFlags(), CCoinsCacheEntry::FRESH);
+    BOOST_CHECK_EQUAL(n2.second.Next(), &sentinel);
+    BOOST_CHECK_EQUAL(n1.second.Next(), &n2);
+
+    // Check that adding 0 flag has no effect, and doesn't change position
+    n1.second.AddFlags(0, n1, sentinel);
+    BOOST_CHECK_EQUAL(n1.second.GetFlags(), CCoinsCacheEntry::DIRTY);
+    BOOST_CHECK_EQUAL(n1.second.Next(), &n2);
+    BOOST_CHECK_EQUAL(sentinel.second.Next(), &n1);
+    BOOST_CHECK_EQUAL(n2.second.Next(), &sentinel);
+
+    // Check that we can add extra flags, but they don't change our position
+    n1.second.AddFlags(CCoinsCacheEntry::FRESH, n1, sentinel);
+    BOOST_CHECK_EQUAL(n1.second.GetFlags(), CCoinsCacheEntry::DIRTY | CCoinsCacheEntry::FRESH);
+    BOOST_CHECK_EQUAL(n1.second.Next(), &n2);
+    BOOST_CHECK_EQUAL(sentinel.second.Next(), &n1);
+    BOOST_CHECK_EQUAL(n2.second.Next(), &sentinel);
+
+    // Check that we can clear flags then re-add them
+    n1.second.ClearFlags();
+    BOOST_CHECK_EQUAL(n1.second.GetFlags(), 0);
+    BOOST_CHECK_EQUAL(sentinel.second.Next(), &n2);
+
+    // Check that calling `ClearFlags` with 0 flags has no effect
+    n1.second.ClearFlags();
+    BOOST_CHECK_EQUAL(n1.second.GetFlags(), 0);
+    BOOST_CHECK_EQUAL(sentinel.second.Next(), &n2);
+
+    // Adding 0 still has no effect
+    n1.second.AddFlags(0, n1, sentinel);
+    BOOST_CHECK_EQUAL(n1.second.GetFlags(), 0);
+    BOOST_CHECK_EQUAL(sentinel.second.Next(), &n2);
+
+    // But adding DIRTY re-inserts it after n2
+    n1.second.AddFlags(CCoinsCacheEntry::DIRTY, n1, sentinel);
+    BOOST_CHECK_EQUAL(n1.second.GetFlags(), CCoinsCacheEntry::DIRTY);
+    BOOST_CHECK_EQUAL(n2.second.Next(), &n1);
+    BOOST_CHECK_EQUAL(n1.second.Next(), &sentinel);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -127,6 +127,7 @@ FUZZ_TARGET(coins_view, .init = initialize_coins_view)
                 // when they are destroyed.
                 CoinsCachePair sentinel{};
                 sentinel.second.SelfRef(sentinel);
+                size_t usage{0};
                 CCoinsMapMemoryResource resource;
                 CCoinsMap coins_map{0, SaltedOutpointHasher{/*deterministic=*/true}, CCoinsMap::key_equal{}, &resource};
                 LIMITED_WHILE(good_data && fuzzed_data_provider.ConsumeBool(), 10'000)
@@ -145,10 +146,12 @@ FUZZ_TARGET(coins_view, .init = initialize_coins_view)
                     }
                     auto it{coins_map.emplace(random_out_point, std::move(coins_cache_entry)).first};
                     it->second.AddFlags(flags, *it, sentinel);
+                    usage += it->second.coin.DynamicMemoryUsage();
                 }
                 bool expected_code_path = false;
                 try {
-                    coins_view_cache.BatchWrite(coins_map, fuzzed_data_provider.ConsumeBool() ? ConsumeUInt256(fuzzed_data_provider) : coins_view_cache.GetBestBlock());
+                    auto cursor{CoinsViewCacheCursor(usage, sentinel, coins_map, /*will_erase=*/true)};
+                    coins_view_cache.BatchWrite(cursor, fuzzed_data_provider.ConsumeBool() ? ConsumeUInt256(fuzzed_data_provider) : coins_view_cache.GetBestBlock());
                     expected_code_path = true;
                 } catch (const std::logic_error& e) {
                     if (e.what() == std::string{"FRESH flag misapplied to coin that exists in parent cache"}) {

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -127,7 +127,7 @@ FUZZ_TARGET(coins_view, .init = initialize_coins_view)
                 LIMITED_WHILE(good_data && fuzzed_data_provider.ConsumeBool(), 10'000)
                 {
                     CCoinsCacheEntry coins_cache_entry;
-                    coins_cache_entry.AddFlags(fuzzed_data_provider.ConsumeIntegral<unsigned char>());
+                    coins_cache_entry.AddFlags(fuzzed_data_provider.ConsumeIntegral<uint8_t>());
                     if (fuzzed_data_provider.ConsumeBool()) {
                         coins_cache_entry.coin = random_coin;
                     } else {

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -127,7 +127,7 @@ FUZZ_TARGET(coins_view, .init = initialize_coins_view)
                 LIMITED_WHILE(good_data && fuzzed_data_provider.ConsumeBool(), 10'000)
                 {
                     CCoinsCacheEntry coins_cache_entry;
-                    coins_cache_entry.flags = fuzzed_data_provider.ConsumeIntegral<unsigned char>();
+                    coins_cache_entry.AddFlags(fuzzed_data_provider.ConsumeIntegral<unsigned char>());
                     if (fuzzed_data_provider.ConsumeBool()) {
                         coins_cache_entry.coin = random_coin;
                     } else {

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -122,12 +122,17 @@ FUZZ_TARGET(coins_view, .init = initialize_coins_view)
                 random_mutable_transaction = *opt_mutable_transaction;
             },
             [&] {
+                // sentinel must go out of scope and be destroyed after coins_map.
+                // Any remaining flagged entries in coins_map need to reference the sentinel
+                // when they are destroyed.
+                CoinsCachePair sentinel{};
+                sentinel.second.SelfRef(sentinel);
                 CCoinsMapMemoryResource resource;
                 CCoinsMap coins_map{0, SaltedOutpointHasher{/*deterministic=*/true}, CCoinsMap::key_equal{}, &resource};
                 LIMITED_WHILE(good_data && fuzzed_data_provider.ConsumeBool(), 10'000)
                 {
                     CCoinsCacheEntry coins_cache_entry;
-                    coins_cache_entry.AddFlags(fuzzed_data_provider.ConsumeIntegral<uint8_t>());
+                    const auto flags{fuzzed_data_provider.ConsumeIntegral<uint8_t>()};
                     if (fuzzed_data_provider.ConsumeBool()) {
                         coins_cache_entry.coin = random_coin;
                     } else {
@@ -138,7 +143,8 @@ FUZZ_TARGET(coins_view, .init = initialize_coins_view)
                         }
                         coins_cache_entry.coin = *opt_coin;
                     }
-                    coins_map.emplace(random_out_point, std::move(coins_cache_entry));
+                    auto it{coins_map.emplace(random_out_point, std::move(coins_cache_entry)).first};
+                    it->second.AddFlags(flags, *it, sentinel);
                 }
                 bool expected_code_path = false;
                 try {

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -175,7 +175,7 @@ public:
     bool BatchWrite(CCoinsMap& data, const uint256&, bool erase) final
     {
         for (auto it = data.begin(); it != data.end(); it = erase ? data.erase(it) : std::next(it)) {
-            if (it->second.flags & CCoinsCacheEntry::DIRTY) {
+            if (it->second.IsDirty()) {
                 if (it->second.coin.IsSpent() && (it->first.n % 5) != 4) {
                     m_data.erase(it->first);
                 } else if (erase) {

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -172,13 +172,13 @@ public:
     std::unique_ptr<CCoinsViewCursor> Cursor() const final { return {}; }
     size_t EstimateSize() const final { return m_data.size(); }
 
-    bool BatchWrite(CCoinsMap& data, const uint256&, bool erase) final
+    bool BatchWrite(CoinsViewCacheCursor& cursor, const uint256&) final
     {
-        for (auto it = data.begin(); it != data.end(); it = erase ? data.erase(it) : std::next(it)) {
+        for (auto it{cursor.Begin()}; it != cursor.End(); it = cursor.Next(*it)) {
             if (it->second.IsDirty()) {
                 if (it->second.coin.IsSpent() && (it->first.n % 5) != 4) {
                     m_data.erase(it->first);
-                } else if (erase) {
+                } else if (cursor.WillErase(*it)) {
                     m_data[it->first] = std::move(it->second.coin);
                 } else {
                     m_data[it->first] = it->second.coin;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -115,7 +115,7 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, boo
     batch.Write(DB_HEAD_BLOCKS, Vector(hashBlock, old_tip));
 
     for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end();) {
-        if (it->second.flags & CCoinsCacheEntry::DIRTY) {
+        if (it->second.IsDirty()) {
             CoinEntry entry(&it->first);
             if (it->second.coin.IsSpent())
                 batch.Erase(entry);

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -88,7 +88,7 @@ std::vector<uint256> CCoinsViewDB::GetHeadBlocks() const {
     return vhashHeadBlocks;
 }
 
-bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, bool erase) {
+bool CCoinsViewDB::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashBlock) {
     CDBBatch batch(*m_db);
     size_t count = 0;
     size_t changed = 0;
@@ -114,7 +114,7 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, boo
     batch.Erase(DB_BEST_BLOCK);
     batch.Write(DB_HEAD_BLOCKS, Vector(hashBlock, old_tip));
 
-    for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end();) {
+    for (auto it{cursor.Begin()}; it != cursor.End();) {
         if (it->second.IsDirty()) {
             CoinEntry entry(&it->first);
             if (it->second.coin.IsSpent())
@@ -124,7 +124,7 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, boo
             changed++;
         }
         count++;
-        it = erase ? mapCoins.erase(it) : std::next(it);
+        it = cursor.Next(*it);
         if (batch.SizeEstimate() > m_options.batch_write_bytes) {
             LogPrint(BCLog::COINDB, "Writing partial batch of %.2f MiB\n", batch.SizeEstimate() * (1.0 / 1048576.0));
             m_db->WriteBatch(batch);

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -63,7 +63,7 @@ public:
     bool HaveCoin(const COutPoint &outpoint) const override;
     uint256 GetBestBlock() const override;
     std::vector<uint256> GetHeadBlocks() const override;
-    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, bool erase = true) override;
+    bool BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashBlock) override;
     std::unique_ptr<CCoinsViewCursor> Cursor() const override;
 
     //! Whether an unsupported database format is used.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2911,7 +2911,7 @@ bool Chainstate::FlushStateToDisk(
                 return FatalError(m_chainman.GetNotifications(), state, _("Disk space is too low!"));
             }
             // Flush the chainstate (which may refer to block index entries).
-            const auto empty_cache{(mode == FlushStateMode::ALWAYS) || fCacheLarge || fCacheCritical || fFlushForPrune};
+            const auto empty_cache{(mode == FlushStateMode::ALWAYS) || fCacheLarge || fCacheCritical};
             if (empty_cache ? !CoinsTip().Flush() : !CoinsTip().Sync()) {
                 return FatalError(m_chainman.GetNotifications(), state, _("Failed to write to coin database."));
             }


### PR DESCRIPTION
The author **andrewtoth** wrote the following PR called **Don't empty dbcache on prune flushes: >30% faster IBD**, issue number **28280** in **bitcoin/bitcoin** cloned by FreshEyes below:

Since `https://github.com/bitcoin/bitcoin/pull/17487` we no longer need to clear the coins cache when syncing to disk. A warm coins cache significantly speeds up block connection, and only needs to be fully flushed when nearing the `dbcache` limit.

For frequent pruning flushes there's no need to empty the cache and kill connect block speed. However, simply using `Sync` in place of `Flush` actually slows down a pruned full IBD with a high `dbcache` value. This is because as the cache grows, sync takes longer since every coin in the cache is scanned to check if it's dirty. For frequent prune flushes and a large cache this constant scanning starts to really slow IBD down, and just emptying the cache on every prune becomes faster.

To fix this, we can add two pointers to each cache entry and construct a doubly linked list of dirty entries. We can then only iterate through all dirty entries on each `Sync`, and simply clear the pointers after.

With this approach a full IBD with `dbcache=16384` and `prune=550` was 32% faster than master. For default `dbcache=450` speedup was ~9%. All benchmarks were run with `stopatheight=800000`.

|  | prune | dbcache | time | max RSS | speedup |
|-----------:|----------:|------------:|--------:|-------------:|--------------:|
| master | 550 | 16384 | 8:52:57 | 2,417,464k | - |
| branch | 550 | 16384 | 6:01:00 | 16,216,736k | 32% |
| branch | 550 | 450 | 8:05:08 | 2,818,072k | 8.8% |
| master | 10000 | 5000 | 8:19:59 | 2,962,752k | - |
| branch | 10000 | 5000| 5:56:39 | 6,179,764k | 28.8% |
| master | 0 | 16384 | 4:51:53 | 14,726,408k | - |
| branch | 0 | 16384 | 4:43:11 | 16,526,348k | 2.7% |
| master | 0 | 450 | 7:08:07 | 3,005,892k | - |
| branch | 0 | 450 | 6:57:24 | 3,013,556k |2.6%|

While the 2 pointers add memory to each cache entry, it did not slow down IBD. For non-pruned IBD results were similar for this branch and master. When I performed the initial IBD, the full UTXO set could be held in memory when using the max `dbcache` value. For non-pruned IBD with max `Sync`0 to tip ended up using 12% more memory, but it was also 2.7% faster somehow. For smaller `Sync`1 values the `Sync`2 limit is respected so does not consume more memory, and the potentially more frequent flushes were not significant enough to cause any slowdown.

For reviewers, the commits in order do the following:
First 4 commits encapsulate all accesses to `Sync`3 on cache entries, and then the 5th makes `Sync`4 private.
Commits `Sync`5 to `Sync`6 create the linked list head nodes and cache entry self references and pass them into `Sync`7.
Commit `Sync`8 actually adds the entries into a linked list when they are flagged DIRTY or FRESH and removes them from the linked list when they are destroyed or the flags are cleared manually. However, the linked list is not yet used anywhere.
Commit `Sync`9 adds unit tests for the linked list.
Commit `Flush`0 uses the linked list to iterate through DIRTY entries instead of using the entire coins cache.
Commit `Flush`1 uses `Flush`2 instead of `Flush`3 for pruning flushes, so the cache is no longer cleared. 

Inspired by [this comment](`https://github.com/bitcoin/bitcoin/pull/15265#issuecomment-457720636`).

Fixes `https://github.com/bitcoin/bitcoin/issues/11315.`